### PR TITLE
Full corpus v2

### DIFF
--- a/admin_scripts/full_corpus_stats.rb
+++ b/admin_scripts/full_corpus_stats.rb
@@ -31,7 +31,7 @@ dojo.katas.each do |kata|
             num_red, num_green, num_amber = 0, 0, 0
             endsOnGreen = false
 
-            transitions = ""
+            transitions = "["
             lights.each_cons(2) do |was,now|
                 case was.colour.to_s
                 when "red"
@@ -75,7 +75,7 @@ dojo.katas.each do |kata|
             when "amber"
                 num_amber += 1
             end
-            transitions += lights[lights.count-1].colour.to_s
+            transitions += lights[lights.count-1].colour.to_s + "]"
 
 
             if arg == "true"


### PR DESCRIPTION
Reduced the full_corpus_stats.rb file from 138 lines to less than 100 lines, and added additional code to place '[' at the beginning of each cycle and ']' at the end. Switching between printing styles can be accomplished by using the "true" argument option (true provides formatted output, false/blank provides csv format).
